### PR TITLE
Add usage stats and graphs to options page

### DIFF
--- a/src/options/Stats.tsx
+++ b/src/options/Stats.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from "react";
+import { Journey } from "../types/journey";
+import { StorageHandler } from "../background/controllers/storage";
+
+export const Stats: React.FC = () => {
+  const [journeys, setJourneys] = useState<Journey[]>([]);
+
+  useEffect(() => {
+    StorageHandler.getJournies().then(setJourneys);
+  }, []);
+
+  const totalHours = journeys.reduce(
+    (sum, j) => sum + j.totalHoursLogged,
+    0
+  );
+  const totalLogs = journeys.reduce((sum, j) => sum + j.logs.length, 0);
+  const lineData = React.useMemo(() => {
+    const logs = journeys.flatMap((j) =>
+      j.logs.map((l) => ({ date: new Date(l.date), hours: l.hoursWorked }))
+    );
+    logs.sort((a, b) => a.date.getTime() - b.date.getTime());
+    let cumulative = 0;
+    return logs.map((log) => {
+      cumulative += log.hours;
+      return { date: log.date, value: cumulative };
+    });
+  }, [journeys]);
+
+  const maxLineValue = lineData.reduce((max, l) => Math.max(max, l.value), 0) || 1;
+  const linePoints = lineData
+    .map((p, i) => {
+      const x = lineData.length > 1 ? (i / (lineData.length - 1)) * 100 : 50;
+      const y = 100 - (p.value / maxLineValue) * 100;
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  const maxHoursPerJourney =
+    journeys.reduce((max, j) => Math.max(max, j.totalHoursLogged), 0) || 1;
+
+  if (journeys.length === 0) {
+    return (
+      <p className="text-center text-gray-400">No journey data found.</p>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-4 max-w-5xl mx-auto">
+      <div className="grid grid-cols-3 text-center gap-4">
+        <div>
+          <p className="text-sm text-gray-500">Journeys</p>
+          <p className="text-lg font-bold">{journeys.length}</p>
+        </div>
+        <div>
+          <p className="text-sm text-gray-500">Logs</p>
+          <p className="text-lg font-bold">{totalLogs}</p>
+        </div>
+        <div>
+          <p className="text-sm text-gray-500">Hours Logged</p>
+          <p className="text-lg font-bold">{totalHours.toFixed(1)}</p>
+        </div>
+      </div>
+      <div>
+        <h3 className="font-semibold mb-2">Hours Logged per Journey</h3>
+        <div className="space-y-2">
+          {journeys.map((j) => (
+            <div key={j.id}>
+              <p className="text-sm mb-1">{j.name}</p>
+              <div className="w-full bg-gray-200 h-3 rounded">
+                <div
+                  className="bg-blue-600 h-3 rounded"
+                  style={{
+                    width: `${(j.totalHoursLogged / maxHoursPerJourney) * 100}%`,
+                  }}
+                ></div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      {lineData.length > 0 && (
+        <div>
+          <h3 className="font-semibold mb-2">Cumulative Hours Over Time</h3>
+          <svg
+            viewBox="0 0 100 100"
+            className="w-full h-40 bg-gray-100 rounded"
+            preserveAspectRatio="none"
+          >
+            <polyline
+              fill="none"
+              stroke="#4f46e5"
+              strokeWidth="2"
+              points={linePoints}
+            />
+          </svg>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Stats;

--- a/src/options/options.tsx
+++ b/src/options/options.tsx
@@ -22,6 +22,7 @@ import {
 } from "../background/controllers/alarms";
 import PermissionsModel from "../chrome-api/permissions";
 import Toaster from "../utils/web-components/Toaster";
+import Stats from "./Stats";
 Toaster.registerSelf();
 
 const optionalPermissions = new PermissionsModel({
@@ -195,6 +196,7 @@ const App: React.FC<{}> = () => {
           scope.
         </p>
       </div>
+      <Stats />
       <toaster-element
         ref={toasterRef}
         data-position="top-right"


### PR DESCRIPTION
## Summary
- add a new `Stats` component to show metrics for journeys
- display total journeys, logs, and hours in stats component
- render bar and line graphs using SVG without extra deps
- include the stats component on the Options page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687eaddf6adc832285f30d402555ad8f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new statistics dashboard displaying journey summaries, including total journeys, total logs, and total hours logged.
  * Introduced visual charts: a horizontal bar chart for hours per journey and a line chart for cumulative hours over time.
  * The dashboard appears in the options page, providing an overview of logged data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->